### PR TITLE
Add WebSocket demo with client list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "temporary-nodejs-demo",
+  "version": "1.0.0",
+  "description": "Testing to see how the Render service works.",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "ws": "^8.14.2"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>WebSocket Demo</title>
+  <style>
+    #status.connected { color: green; }
+    #status.disconnected { color: red; }
+  </style>
+</head>
+<body>
+  <button id="connect">Connect</button>
+  <button id="disconnect" disabled>Disconnect</button>
+  <span id="status" class="disconnected">Disconnected</span>
+
+  <h3>Connected clients:</h3>
+  <ul id="clients"></ul>
+
+  <script>
+    let socket;
+    let intervalId;
+    const connectBtn = document.getElementById('connect');
+    const disconnectBtn = document.getElementById('disconnect');
+    const statusSpan = document.getElementById('status');
+    const clientsList = document.getElementById('clients');
+
+    function updateStatus(connected) {
+      statusSpan.textContent = connected ? 'Connected' : 'Disconnected';
+      statusSpan.className = connected ? 'connected' : 'disconnected';
+      connectBtn.disabled = connected;
+      disconnectBtn.disabled = !connected;
+    }
+
+    connectBtn.addEventListener('click', () => {
+      socket = new WebSocket(`ws://${location.host}`);
+      socket.addEventListener('open', () => {
+        updateStatus(true);
+        intervalId = setInterval(() => {
+          socket.send(JSON.stringify({ type: 'list' }));
+        }, 2000);
+      });
+      socket.addEventListener('message', (event) => {
+        const data = JSON.parse(event.data);
+        if (data.type === 'list') {
+          clientsList.innerHTML = '';
+          data.clients.forEach(id => {
+            const li = document.createElement('li');
+            li.textContent = id;
+            clientsList.appendChild(li);
+          });
+        }
+      });
+      socket.addEventListener('close', () => {
+        updateStatus(false);
+        clientsList.innerHTML = '';
+        clearInterval(intervalId);
+      });
+    });
+
+    disconnectBtn.addEventListener('click', () => {
+      if (socket) {
+        socket.close();
+      }
+    });
+
+    updateStatus(false);
+  </script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,38 @@
+const express = require('express');
+const http = require('http');
+const { WebSocketServer } = require('ws');
+
+const app = express();
+const server = http.createServer(app);
+const wss = new WebSocketServer({ server });
+
+const clients = new Map();
+let nextId = 1;
+
+wss.on('connection', (ws) => {
+  const id = `client-${nextId++}`;
+  clients.set(ws, id);
+
+  ws.on('message', (message) => {
+    try {
+      const data = JSON.parse(message);
+      if (data.type === 'list') {
+        const list = Array.from(clients.values());
+        ws.send(JSON.stringify({ type: 'list', clients: list }));
+      }
+    } catch (err) {
+      // ignore invalid messages
+    }
+  });
+
+  ws.on('close', () => {
+    clients.delete(ws);
+  });
+});
+
+app.use(express.static('public'));
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server listening on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- serve a simple web page and WebSocket handler via Express
- allow clients to connect/disconnect and request connected client list

## Testing
- `npm test`
- `npm install` *(failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68be40154430832b87166eeb1aecd77b