### PR TITLE
Add health check endpoint

### DIFF
--- a/server.js
+++ b/server.js
@@ -30,6 +30,11 @@ wss.on('connection', (ws) => {
   });
 });
 
+// Health check endpoint
+app.get('/is-running', (req, res) => {
+  res.send('OK');
+});
+
 app.use(express.static('public'));
 
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- add /is-running health check endpoint returning OK

## Testing
- `npm test`
- `node server.js` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68be44e18658832bb1da7a3877b78ad1