### PR TITLE
Fix WebSocket mixed content and favicon 404

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>WebSocket Demo</title>
+  <link rel="icon" href="data:,">
   <style>
     #status.connected { color: green; }
     #status.disconnected { color: red; }
@@ -32,7 +33,8 @@
     }
 
     connectBtn.addEventListener('click', () => {
-      socket = new WebSocket(`ws://${location.host}`);
+      const protocol = location.protocol === 'https:' ? 'wss' : 'ws';
+      socket = new WebSocket(`${protocol}://${location.host}`);
       socket.addEventListener('open', () => {
         updateStatus(true);
         intervalId = setInterval(() => {

--- a/server.js
+++ b/server.js
@@ -35,6 +35,8 @@ app.get('/is-running', (req, res) => {
   res.send('OK');
 });
 
+app.get('/favicon.ico', (req, res) => res.status(204).end());
+
 app.use(express.static('public'));
 
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- Use secure WebSocket connections when page is loaded via HTTPS
- Suppress missing favicon requests and respond with no-content route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be4863af08832b9090bde649a41cc4